### PR TITLE
修复Class redis does not exist和Class cache does not exist

### DIFF
--- a/src/Forone/Providers/ForoneServiceProvider.php
+++ b/src/Forone/Providers/ForoneServiceProvider.php
@@ -65,6 +65,11 @@ class ForoneServiceProvider extends ServiceProvider
 
     private function registerProvider()
     {
+
+        //当.env配置 SESSION_DRIVER=redis 时注册RedisServiceProvider和CacheServiceProvider
+        $this->app->register(\Illuminate\Redis\RedisServiceProvider::class);
+        $this->app->register(\Illuminate\Cache\CacheServiceProvider::class);
+
         $this->app->register(\Illuminate\Translation\TranslationServiceProvider::class);
         $this->app->register(\Illuminate\Html\HtmlServiceProvider::class);
         $this->app->register(\Orangehill\Iseed\IseedServiceProvider::class);


### PR DESCRIPTION
local.ERROR: exception 'ReflectionException' with message 'Class cache does not exist'
local.ERROR: exception 'ReflectionException' with message 'Class redis does not exist'
