### PR TITLE
更新zizaco/entrust版本为5.2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "type": "project",
   "require": {
       "php": ">=5.5.9",
-      "laravel/framework": "5.2.x-dev",
+      "laravel/framework": "5.2.*",
       "qiniu/php-sdk": "v7.0.4",
       "orangehill/iseed": "^2.0",
       "doctrine/dbal": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "forone/administrator",
   "description": "Admin system based on Laravel 5.2",
-  "homepage": "https://github.com/ForoneTech/LaravelAdmin",
+  "homepage": "https://github.com/ForoneTech/ForoneAdministrator",
   "keywords": ["framework", "laravel","forone","laravel 5.2"],
   "license": "MIT",
   "type": "project",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "forone/administrator",
   "description": "Admin system based on Laravel 5.2",
-  "homepage": "https://github.com/ForoneTech/ForoneAdministrator",
+  "homepage": "https://github.com/ForoneTech/LaravelAdmin",
   "keywords": ["framework", "laravel","forone","laravel 5.2"],
   "license": "MIT",
   "type": "project",
@@ -12,7 +12,7 @@
       "orangehill/iseed": "^2.0",
       "doctrine/dbal": "~2.3",
       "laravelcollective/html": "5.2.*",
-      "zizaco/entrust": "dev-laravel-5",
+      "zizaco/entrust": "5.2.x-dev",
       "forone/administrator": "5.2.x-dev"
   },
   "require-dev": {


### PR DESCRIPTION
原来版本为dev-laravel-5一直找不到，更新zizaco/entrust版本为5.2.x-dev
