### PR TITLE
fix(表单验证错误时关联模型数据不维持): 更改为优先读取表单字段数据

### DIFF
--- a/src/Forone/Providers/ForoneFormServiceProvider.php
+++ b/src/Forone/Providers/ForoneFormServiceProvider.php
@@ -41,6 +41,11 @@ class ForoneFormServiceProvider extends ServiceProvider
 
     public static function parseValue($model, $name)
     {
+        // 兼容 ValidationException
+        if (isset($model[$name])) {
+            return $model[$name];
+        }
+
         $arr = explode('-', $name);
         if (sizeof($arr) == 2) {
             return $model && (!is_array($model) && isset($model[$arr[0]][$arr[1]])) ? $model[$arr[0]][$arr[1]] : '';


### PR DESCRIPTION
关联数据如 detail-info 在表单验证错误之后，而是读取相关的关联关系，不会自动恢复。

目前的设定是，优先从 session 中读取 detail-info 信息，如果不存在，则获取相关的关联关系。
